### PR TITLE
migrate devcontainer to docker compose

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,11 +4,11 @@
 ARG VARIANT="3.9"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# Install other dependencies:
+RUN apt-get update -qq -y \
+    && apt-get install -y \
+        postgresql-client
 
 # Copy install and launcher script to bin:
-COPY ./.devcontainer/dev_install /bin
-COPY ./.devcontainer/dev_launcher /bin
+COPY ./dev_install /bin
+COPY ./dev_launcher /bin

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,17 +2,18 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/python-3
 {
 	"name": "Python 3",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"context": "..",
-		"args": { 
-			// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
-			"VARIANT": "3.9",
-			// Options
-			"INSTALL_NODE": "false",
-			"NODE_VERSION": "lts/*"
-		}
-	},
+
+	"dockerComposeFile": [
+		"docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "storage_service",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/workspace",
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,62 @@
+version: '3.2'
+services:
+  storage_service:
+
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    
+    command: /bin/sh -c "while sleep 1000; do :; done"
+      
+    ports:
+      - target: 8080
+        published: 8080
+        protocol: tcp
+        mode: host
+
+    environment:
+      DB_URL: postgresql://admin:admin@postgresql/storage
+      S3_URL: http://localstack:4566 # to be adapted
+
+    volumes:
+      - ..:/workspace:cached
+
+  postgresql:
+    image: "postgres:13-alpine"
+    volumes:
+      - type: volume
+        source: db_fs
+        target: /var/lib/postgresql/data
+        volume:
+          nocopy: true
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+    command: ['postgres', '-c', 'work_mem=512MB']
+    deploy:
+      endpoint_mode : dnsrr
+
+  s3_localstack:
+    image: localstack/localstack
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=s3
+      - DEFAULT_REGION=eu-west-1
+      - AWS_DEFAULT_REGION=eu-west-1
+      - HOSTNAME_EXTERNAL=localhost # accessible at localhost
+      - USE_SSL=false
+      - DATA_DIR=/tmp/localstack/data
+      - DEBUG=1
+    volumes:
+      - type: volume
+        source: s3_fs
+        target: /tmp/localstack
+        volume:
+          nocopy: true
+
+volumes:
+  db_fs:
+    external: false
+  s3_fs:
+    external: false


### PR DESCRIPTION
Migrate Dockerfile-based devcontainer environment to docker compose.
Included following image in addition to primary dev image:
- postgresql
- localstack for s3