### PR TITLE
Feature/fix openapiyaml link gdev 214

### DIFF
--- a/.devcontainer/.sandbox_storage.yaml
+++ b/.devcontainer/.sandbox_storage.yaml
@@ -3,6 +3,7 @@ port: 8080
 log_level: info
 drs_path: drs://localhost:8080/
 api_path: /ga4gh/drs/v1
+custom_spec_url: https://localhost:8080/ga4gh/drs/v1/openapi.yaml
 cors_allowed_origins: ["*"]
 cors_allow_credentials: true
 cors_allowed_methods: ["*"]

--- a/.devcontainer/dev_launcher
+++ b/.devcontainer/dev_launcher
@@ -1,2 +1,3 @@
 #!/bin/bash
+cd /workspace/.devcontainer
 sandbox-storage

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -7,3 +7,6 @@ cors_allowed_origins: ["http://the-other-domain-to-accept.xy"]
 cors_allow_credentials: true
 cors_allowed_methods: ["*"]
 cors_allowed_headers: ["*"]
+
+# only use when you want to hard-code the spec url:
+custom_spec_url: http://localhost:8080/ga4gh/drs/v1/openapi.yaml

--- a/sandbox_storage/config.py
+++ b/sandbox_storage/config.py
@@ -17,7 +17,7 @@
 This module provides Configuration for the API
 """
 
-from typing import List
+from typing import List, Optional
 from functools import lru_cache
 from ghga_service_chassis_lib.config import config_from_yaml
 from ghga_service_chassis_lib.api import LogLevel
@@ -35,6 +35,7 @@ class Config(BaseSettings):
     log_level: LogLevel = "info"
     drs_path: str = "drs://localhost:8080/"
     api_path: str = "/ga4gh/drs/v1"
+    custom_spec_url: Optional[str] = None
     rabbitmq_host: str = "rabbitmq"
     rabbitmq_port: int = 5672
     topic_name: str = "download_request"

--- a/sandbox_storage/custom_openapi3/__init__.py
+++ b/sandbox_storage/custom_openapi3/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Customize the pyramid-openapi3 framework"""

--- a/sandbox_storage/custom_openapi3/custom_explorer_view.py
+++ b/sandbox_storage/custom_openapi3/custom_explorer_view.py
@@ -1,0 +1,80 @@
+# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Customize the pyramid-openapi3 swagger explorer"""
+
+from pathlib import Path
+from typing import Optional
+from string import Template
+
+from pyramid.config import Configurator
+from pyramid.request import Request
+from pyramid.response import Response
+from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.exceptions import ConfigurationError
+from pyramid.config import PHASE0_CONFIG
+
+HERE = Path(__file__).parent.resolve()
+SWAGGER_HTML = HERE / "swagger.html"
+
+
+def add_custom_explorer_view(  # pylint: disable=too-many-arguments
+    config: Configurator,
+    route: str = "/docs/",
+    route_name: str = "pyramid_openapi3.explorer",
+    ui_version: str = "3.17.1",
+    permission: str = NO_PERMISSION_REQUIRED,
+    apiname: str = "pyramid_openapi3",
+    custom_spec_url: Optional[str] = None,
+) -> None:
+    """
+    Modified from
+    https://github.com/Pylons/pyramid_openapi3/blob/d181ac4bc7baa7cae50ab16797d6cb5b7c3ae24c/pyramid_openapi3/__init__.py#L130
+    to make the target openapi.yaml URL configurable.
+
+    :param route: URL path where to serve
+    :param route_name: Route name that's being added
+    :param ui_version: Swagger UI version string
+    :param permission: Permission for the explorer view
+    :param permission: Permission for the explorer view
+    """
+
+    def register() -> None:
+        def explorer_view(request: Request) -> Response:
+            settings = config.registry.settings
+            if settings.get(apiname) is None:
+                raise ConfigurationError(
+                    "You need to call config.pyramid_openapi3_spec for the explorer "
+                    "to work."
+                )
+            with open(SWAGGER_HTML) as file:
+                template = Template(file.read())
+                spec_url = (
+                    custom_spec_url
+                    if custom_spec_url
+                    else request.route_url(settings[apiname]["spec_route_name"])
+                )
+                html = template.safe_substitute(
+                    ui_version=ui_version,
+                    spec_url=spec_url,
+                )
+            return Response(html)
+
+        config.add_route(route_name, route)
+        config.add_view(
+            route_name=route_name, permission=permission, view=explorer_view
+        )
+
+    config.action((f"{apiname}_add_explorer",), register, order=PHASE0_CONFIG)

--- a/sandbox_storage/custom_openapi3/custom_explorer_view.py
+++ b/sandbox_storage/custom_openapi3/custom_explorer_view.py
@@ -30,6 +30,10 @@ HERE = Path(__file__).parent.resolve()
 SWAGGER_HTML = HERE / "swagger.html"
 
 
+# ignore some pylint error
+# as this code comes directly from
+# pyramid-openapi and should thus
+# be mpdofied as little as possible:
 def add_custom_explorer_view(  # pylint: disable=too-many-arguments
     config: Configurator,
     route: str = "/docs/",
@@ -59,7 +63,7 @@ def add_custom_explorer_view(  # pylint: disable=too-many-arguments
                     "You need to call config.pyramid_openapi3_spec for the explorer "
                     "to work."
                 )
-            with open(SWAGGER_HTML) as file:
+            with open(SWAGGER_HTML) as file:  # pylint: disable=unspecified-encoding
                 template = Template(file.read())
                 spec_url = (
                     custom_spec_url

--- a/sandbox_storage/custom_openapi3/swagger.html
+++ b/sandbox_storage/custom_openapi3/swagger.html
@@ -1,0 +1,106 @@
+<!-- HTML for static distribution bundle build -->
+<!--
+    From:
+    https://raw.githubusercontent.com/Pylons/pyramid_openapi3/d181ac4bc7baa7cae50ab16797d6cb5b7c3ae24c/pyramid_openapi3/static/index.html
+-->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link
+        href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700"
+        rel="stylesheet">
+    <link rel="stylesheet" type="text/css"
+        href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/${ui_version}/swagger-ui.css">
+    <style>
+        html {
+            box-sizing: border-box;
+            overflow: -moz-scrollbars-vertical;
+            overflow-y: scroll;
+        }
+
+        *,
+        *:before,
+        *:after {
+            box-sizing: inherit;
+        }
+
+        body {
+            margin: 0;
+            background: #fafafa;
+        }
+    </style>
+</head>
+
+<body>
+
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+        style="position:absolute;width:0;height:0">
+        <defs>
+            <symbol viewBox="0 0 20 20" id="unlocked">
+                <path
+                    d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z">
+                </path>
+            </symbol>
+
+            <symbol viewBox="0 0 20 20" id="locked">
+                <path
+                    d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8zM12 8H8V5.199C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8z" />
+            </symbol>
+
+            <symbol viewBox="0 0 20 20" id="close">
+                <path
+                    d="M14.348 14.849c-.469.469-1.229.469-1.697 0L10 11.819l-2.651 3.029c-.469.469-1.229.469-1.697 0-.469-.469-.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-.469-.469-.469-1.228 0-1.697.469-.469 1.228-.469 1.697 0L10 8.183l2.651-3.031c.469-.469 1.228-.469 1.697 0 .469.469.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c.469.469.469 1.229 0 1.698z" />
+            </symbol>
+
+            <symbol viewBox="0 0 20 20" id="large-arrow">
+                <path
+                    d="M13.25 10L6.109 2.58c-.268-.27-.268-.707 0-.979.268-.27.701-.27.969 0l7.83 7.908c.268.271.268.709 0 .979l-7.83 7.908c-.268.271-.701.27-.969 0-.268-.269-.268-.707 0-.979L13.25 10z" />
+            </symbol>
+
+            <symbol viewBox="0 0 20 20" id="large-arrow-down">
+                <path
+                    d="M17.418 6.109c.272-.268.709-.268.979 0s.271.701 0 .969l-7.908 7.83c-.27.268-.707.268-.979 0l-7.908-7.83c-.27-.268-.27-.701 0-.969.271-.268.709-.268.979 0L10 13.25l7.418-7.141z" />
+            </symbol>
+
+
+            <symbol viewBox="0 0 24 24" id="jump-to">
+                <path d="M19 7v4H5.83l3.58-3.59L8 6l-6 6 6 6 1.41-1.41L5.83 13H21V7z" />
+            </symbol>
+
+            <symbol viewBox="0 0 24 24" id="expand">
+                <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z" />
+            </symbol>
+
+        </defs>
+    </svg>
+
+    <div id="swagger-ui"></div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/${ui_version}/swagger-ui-bundle.js"> </script>
+    <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/${ui_version}/swagger-ui-standalone-preset.js"> </script>
+    <script>
+        window.onload = function () {
+            // Build a system
+            const ui = SwaggerUIBundle({
+                url: "${spec_url}",
+                dom_id: '#swagger-ui',
+                deepLinking: true,
+                presets: [
+                    SwaggerUIBundle.presets.apis,
+                    SwaggerUIStandalonePreset
+                ],
+                plugins: [
+                    SwaggerUIBundle.plugins.DownloadUrl
+                ],
+                layout: "StandaloneLayout"
+            })
+            window.ui = ui
+        }
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
Suggestion for Squash and Merge:

Title:
```
Customize URL to spec in the Swagger-UI (GDEV-214)
```


Description:
```
The path to the OpenApi spec that is used in the Swagger-UI
can now be overwritten by a custom URL.
```