### PR TITLE
Feature/fix missing package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,8 @@ setup(
     url="",
     keywords="",
     packages=find_packages(),
+    package_dir={"sandbox_storage": "sandbox_storage"},
+    package_data={"sandbox_storage": ["custom_openapi3/swagger.html"]},
     license="Apache 2.0",
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Suggestion for Squash and Merge:

Title:
```
Fixed missing package data
```

Description:
```
The `swagger.html` file was not included in the package when installing
without pip's `-e` flag.
Now this file is included in the package data.
```