### PR TITLE
Feature/send msg when object access (GDEV-220)

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -13,13 +13,10 @@ custom_spec_url: http://localhost:8080/ga4gh/drs/v1/openapi.yaml
 # Async messaging:
 rabbitmq_host: rabbitmq
 rabbitmq_port: 5672
-topic_name: download_request
+topic_name_download_requested: download_request
 
 # CORS:
 cors_allowed_origins: ["http://the-other-domain-to-accept.xy"]
 cors_allow_credentials: true
 cors_allowed_methods: ["*"]
 cors_allowed_headers: ["*"]
-
-# only use when you want to hard-code the spec url:
-custom_spec_url: http://localhost:8080/ga4gh/drs/v1/openapi.yaml

--- a/sandbox_storage/api.py
+++ b/sandbox_storage/api.py
@@ -193,6 +193,8 @@ def get_objects_id(request: Request) -> DrsReturnObject:
             access_methods=[access_method],
         )
 
+        send_message(object_id, "s3", "user_id")
+
         return drs_object
 
     raise HTTPNotFound(

--- a/sandbox_storage/config.py
+++ b/sandbox_storage/config.py
@@ -38,7 +38,7 @@ class Config(BaseSettings):
     custom_spec_url: Optional[str] = None
     rabbitmq_host: str = "rabbitmq"
     rabbitmq_port: int = 5672
-    topic_name: str = "download_request"
+    topic_name_download_requested: str = "download_request"
     db_url: str = "postgresql://admin:admin@postgresql/storage"
     s3_url: str = "http://s3-localstack:4566"
 

--- a/sandbox_storage/pubsub.py
+++ b/sandbox_storage/pubsub.py
@@ -51,7 +51,7 @@ def send_message(drs_id: str, access_id: str, user_id: str) -> None:
     message = {"drs_id": drs_id, "access_id": access_id, "user_id": user_id}
     topic = AmqpTopic(
         connection_params=get_connection_params(),
-        topic_name=config.topic_name,
+        topic_name=config.topic_name_download_requested,
         service_name="storage",
     )
     topic.publish(message)


### PR DESCRIPTION
Suggestion for Squash and Merge:

Title:
```
send message when object accessed (GDEV-220)
```

Description:
```
Not only sends message via download_request topic for the `/object/{object_id}/access/{access_id}` endpoint 
but also for the  `/object/{object_id}` endpoint.
```